### PR TITLE
Review of Haskell memory usage blog post

### DIFF
--- a/posts/Haskell-Storable-Vector-overhead.md
+++ b/posts/Haskell-Storable-Vector-overhead.md
@@ -30,7 +30,7 @@ data Vector a = Vector {-# UNPACK #-} !Int
 ```
 
 The `{-# UNPACK #-}` pragma is a memory saving technique:
-Usually GHC would store store (into the memory behind the `Vector` value constructor) pointers to the `Int` and `ForeignPtr a` constructors.
+Usually GHC would store (into the memory behind the `Vector` value constructor) pointers to the `Int` and `ForeignPtr a` constructors.
 The pragma makes GHC store their _actual_ constructors directly, in place of those pointers.
 You can read more about this pragma [in the docs](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/exts/pragmas.html#unpack-pragma).
 It only works on _strict_ constructor fields (indicated by a _bang_ `!`).
@@ -152,7 +152,7 @@ In that case, the N Storable Vectors would be heap objects, and must carry aroun
 
 Thus their total memory usage would be `7 + 1 = 8 Words`, so 64 Bytes.
 
-This result is different from from the incorrect 9 Words we obtained before.
+This result is different from the incorrect 9 Words we obtained before.
 
 
 ## Alternative how to count


### PR DESCRIPTION
Some comments:

* `UNPACK` is more than a memory saving technique, it's also an optimization by increasing effectiveness of cache lines
* "For a `data` type that has multiple constructors" unless you're planning on getting into unboxed sums and other such topics, even single constructor types need a tag in GHC, unless I'm completely mistaken. I see your point (3), which may be what you're getting at, but point (2) doesn't seem correct on its own.
* Just a comment at "How to count": Ouch, I didn't realize `MutableByteArray#` in `PlainPtr` wasn't going to be unpacked... that's where this post is heading, right?
* Instead of normal Vector, I'd call them Boxed
* The section "Alternative how to count" didn't really add much for me

One question I'm left with: would unboxed sums somehow be able to help optimize this at all?